### PR TITLE
Add admin controller for OOS product notifications

### DIFF
--- a/classes/MailAlert.php
+++ b/classes/MailAlert.php
@@ -36,10 +36,12 @@ use Db;
 use Hook;
 use Language;
 use Mail;
+use MailAlerts;
 use ObjectModel;
 use PrestaShopException;
 use Product;
 use Shop;
+use Tools;
 use Validate;
 
 if (!defined('_TB_VERSION_')) {
@@ -64,6 +66,9 @@ class MailAlert extends ObjectModel
             'id_product_attribute' => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true],
             'id_shop'              => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true],
             'id_lang'              => ['type' => self::TYPE_INT, 'validate' => 'isUnsignedInt', 'required' => true],
+            'ip_hash'              => ['type' => self::TYPE_STRING, 'validate' => 'isAnything'],
+            'ip_mask'              => ['type' => self::TYPE_STRING, 'validate' => 'isAnything'],
+            'user_agent'           => ['type' => self::TYPE_STRING, 'validate' => 'isAnything'],
             'date_add'             => ['type' => self::TYPE_DATE,   'validate' => 'isDate'],
         ],
     ];
@@ -102,6 +107,108 @@ class MailAlert extends ObjectModel
      * @var string
      */
     public $date_add;
+
+    /**
+     * @var string
+     */
+    public $ip_hash;
+
+    /**
+     * @var string
+     */
+    public $ip_mask;
+
+    /**
+     * @var string
+     */
+    public $user_agent;
+
+    /**
+     * Override add to store IP and user agent
+     *
+     * @param bool $autoDate
+     * @param bool $nullValues
+     * @return bool
+     * @throws PrestaShopException
+     */
+    public function add($autoDate = true, $nullValues = false)
+    {
+        self::pruneExpired();
+
+        $ua = isset($_SERVER['HTTP_USER_AGENT']) ? Tools::substr($_SERVER['HTTP_USER_AGENT'], 0, 255) : null;
+
+        $data = [
+            'id_customer' => (int) $this->id_customer,
+            'customer_email' => pSQL($this->customer_email),
+            'id_product' => (int) $this->id_product,
+            'id_product_attribute' => (int) $this->id_product_attribute,
+            'id_shop' => (int) $this->id_shop,
+            'id_lang' => (int) $this->id_lang,
+            'date_add' => ['type' => 'sql', 'value' => 'NOW()'],
+        ];
+
+        if (self::hasColumn('ip_hash') && self::hasColumn('ip_mask')) {
+            $ipStr  = Tools::getRemoteAddr();
+            $ipBin  = MailAlerts::ipToBin($ipStr);
+            $ipHash = MailAlerts::hashIpBinary($ipBin);
+            $ipMask = MailAlerts::maskIpBinary($ipBin);
+
+            if ($ipHash) {
+                $data['ip_hash'] = ['type' => 'sql', 'value' => '0x' . bin2hex($ipHash)];
+            }
+            if ($ipMask) {
+                $data['ip_mask'] = ['type' => 'sql', 'value' => '0x' . bin2hex($ipMask)];
+            }
+        }
+
+        if ($ua && self::hasColumn('user_agent')) {
+            $data['user_agent'] = pSQL($ua);
+        }
+
+        $res = Db::getInstance()->insert(static::$definition['table'], $data);
+        if ($res) {
+            $this->id = Db::getInstance()->Insert_ID();
+        }
+
+        return $res;
+    }
+
+    /**
+     * Check if subscription table has a column
+     *
+     * @param string $column
+     *
+     * @return bool
+     */
+    public static function hasColumn($column)
+    {
+        static $columns = null;
+        if ($columns === null) {
+            $rows = Db::getInstance()->executeS('SHOW COLUMNS FROM `'._DB_PREFIX_.static::$definition['table'].'`');
+            $columns = [];
+            if (is_array($rows)) {
+                foreach ($rows as $row) {
+                    $columns[$row['Field']] = true;
+                }
+            }
+        }
+
+        return isset($columns[$column]);
+    }
+
+    /**
+     * Remove expired notification requests
+     */
+    public static function pruneExpired()
+    {
+        $days = (int) Configuration::get('MAILALERTS_OOS_RETENTION_DAYS');
+        if ($days > 0) {
+            Db::getInstance()->delete(
+                static::$definition['table'],
+                'date_add < DATE_SUB(NOW(), INTERVAL ' . (int) $days . ' DAY)'
+            );
+        }
+    }
 
     /**
      * @param int $idCustomer
@@ -284,11 +391,11 @@ class MailAlert extends ObjectModel
      *
      * @throws PrestaShopException
      */
-    public static function sendCustomerAlert($idProduct, $idProductAttribute)
+    public static function sendCustomerAlert($idProduct, $idProductAttribute, $idShop = null)
     {
         $link = Context::getContext()->link;
         $context = Context::getContext()->cloneContext();
-        $customers = static::getCustomers($idProduct, $idProductAttribute);
+        $customers = static::getCustomers($idProduct, $idProductAttribute, $idShop);
 
         foreach ($customers as $customer) {
             $idShop = (int) $customer['id_shop'];
@@ -354,12 +461,29 @@ class MailAlert extends ObjectModel
      *
      * @throws PrestaShopException
      */
-    public static function getCustomers($idProduct, $idProductAttribute)
+    public static function getCustomers($idProduct, $idProductAttribute, $idShop = null)
     {
+        $ctx = Context::getContext();
+        $idShop = $idShop !== null ? (int) $idShop : (int) $ctx->shop->id;
+
+        $shopIds = [$idShop];
+        if (self::hasColumn('id_shop')) {
+            $idGroup = (int) $ctx->shop->id_shop_group;
+            $group = new \ShopGroup($idGroup);
+            if (!empty($group->share_stock)) {
+                $shops = \Shop::getShops(true, $idGroup);
+                $shopIds = array_map(static function ($s) { return (int) $s['id_shop']; }, (array) $shops);
+            }
+        }
+
+        $in = implode(',', array_map('intval', $shopIds));
+
         $sql = '
-			SELECT id_customer, customer_email, id_shop, id_lang
-			FROM `'._DB_PREFIX_.static::$definition['table'].'`
-			WHERE `id_product` = '.(int) $idProduct.' AND `id_product_attribute` = '.(int) $idProductAttribute;
+        SELECT id_customer, customer_email, id_shop, id_lang
+        FROM `'._DB_PREFIX_.static::$definition['table'].'`
+        WHERE `id_product` = '.(int) $idProduct.'
+          AND `id_product_attribute` = '.(int) $idProductAttribute.'
+          AND `id_shop` IN ('.$in.')';
 
         $result = Db::getInstance(_PS_USE_SQL_SLAVE_)->executeS($sql);
         return is_array($result) ? $result : [];

--- a/controllers/admin/AdminMailalertsOosController.php
+++ b/controllers/admin/AdminMailalertsOosController.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+require_once __DIR__.'/../../classes/autoload.php';
+
+use MailAlertModule\MailAlert;
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+class AdminMailalertsOosController extends ModuleAdminController
+{
+    public function __construct()
+    {
+        $this->bootstrap = true;
+        parent::__construct();
+    }
+
+    public function initPageHeaderToolbar()
+    {
+        parent::initPageHeaderToolbar();
+        $this->page_header_toolbar_btn['settings'] = [
+            'href' => $this->context->link->getAdminLink('AdminModules', true, ['configure' => 'mailalerts']),
+            'desc' => $this->l('Settings'),
+            'icon' => 'process-icon-cogs',
+        ];
+    }
+
+    /**
+     * Handle delete action for a subscription
+     */
+    public function postProcess()
+    {
+        if (Tools::isSubmit('delete' . MailAlert::$definition['table'])) {
+            if (!$this->checkToken()) {
+                $this->errors[] = $this->l('Invalid token.');
+                return parent::postProcess();
+            }
+            if (!$this->access('delete')) {
+                $this->errors[] = $this->l('You do not have permission to delete this item.');
+                return parent::postProcess();
+            }
+
+            $id = (int) Tools::getValue(MailAlert::$definition['primary']);
+            $idProduct = (int) Tools::getValue('id_product');
+
+            if ($id) {
+                Db::getInstance()->delete(MailAlert::$definition['table'], MailAlert::$definition['primary'].'='.(int)$id);
+                Tools::redirectAdmin($this->context->link->getAdminLink('AdminMailalertsOos', true, ['id_product' => $idProduct]));
+            }
+        }
+
+        parent::postProcess();
+    }
+
+    /**
+     * Render list of products or subscribers
+     *
+     * @return string
+     * @throws PrestaShopDatabaseException
+     * @throws PrestaShopException
+     */
+    public function renderList()
+    {
+        MailAlert::pruneExpired();
+        $idProduct = (int) Tools::getValue('id_product');
+
+        if ($idProduct) {
+            $product = new Product($idProduct, false, $this->context->language->id);
+            $productName = Validate::isLoadedObject($product) ? $product->name : $this->l('Deleted product');
+
+            $fieldsList = [
+                'combination_name' => [
+                    'title' => $this->l('Combination'),
+                    'type' => 'text',
+                ],
+                'customer_name' => [
+                    'title' => $this->l('Customer'),
+                    'type' => 'text',
+                    'callback_object' => $this,
+                    'callback' => 'renderCustomer',
+                ],
+                'customer_email' => [
+                    'title' => $this->l('Email'),
+                ],
+                'date_add' => [
+                    'title' => $this->l('Date'),
+                    'type' => 'datetime',
+                ],
+                'ip_address' => [
+                    'title' => $this->l('IP address'),
+                ],
+                'ip_hash' => [
+                    'title' => $this->l('IP hash'),
+                ],
+                'user_agent' => [
+                    'title' => $this->l('User agent'),
+                ],
+            ];
+
+            if (!$product->hasAttributes()) {
+                unset($fieldsList['combination_name']);
+            }
+
+            $helper = new HelperList();
+            $helper->shopLinkType = '';
+            $helper->simple_header = true;
+            $helper->identifier = MailAlert::$definition['primary'];
+            $helper->actions = ['delete'];
+            $helper->no_link = true;
+            $helper->show_toolbar = false;
+            $helper->table = MailAlert::$definition['table'];
+            $helper->token = Tools::getAdminTokenLite('AdminMailalertsOos');
+            $helper->currentIndex = $this->context->link->getAdminLink('AdminMailalertsOos', false, [
+                'id_product' => $idProduct,
+            ]);
+
+            $title = sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $idProduct);
+            $helper->title = Translate::ppTags($title, ['<a href="' . htmlspecialchars($this->context->link->getAdminLink('AdminMailalertsOos')) . '">']);
+
+            $list = $this->getProductListSubscribers($idProduct);
+            $helper->listTotal = count($list);
+
+            return $this->renderHint() . $helper->generateList($list, $fieldsList);
+        }
+
+        $fieldsList = [
+            'id_product' => [
+                'title' => $this->l('Product ID'),
+            ],
+            'reference' => [
+                'title' => $this->l('Reference'),
+                'callback_object' => $this,
+                'callback' => 'renderProduct',
+            ],
+            'product_name' => [
+                'title' => $this->l('Product Name'),
+                'callback_object' => $this,
+                'callback' => 'renderProduct',
+            ],
+            'combination_name' => [
+                'title' => $this->l('Combination'),
+                'type' => 'text',
+            ],
+            'cnt' => [
+                'title' => $this->l('Number of subscriptions'),
+                'callback_object' => $this,
+                'callback' => 'renderCnt',
+            ],
+        ];
+
+        $helper = new HelperList();
+        $helper->shopLinkType = '';
+        $helper->simple_header = true;
+        $helper->identifier = 'id_product';
+        $helper->actions = [];
+        $helper->no_link = true;
+        $helper->show_toolbar = false;
+        $helper->title = $this->l('Products with notifications');
+        $helper->table = MailAlert::$definition['table'];
+        $helper->token = Tools::getAdminTokenLite('AdminMailalertsOos');
+        $helper->currentIndex = $this->context->link->getAdminLink('AdminMailalertsOos');
+
+        $list = $this->getProductsSubscribers();
+        $helper->listTotal = count($list);
+
+        return $helper->generateList($list, $fieldsList);
+    }
+
+    /**
+     * Get grouped list of subscribed products
+     */
+    protected function getProductsSubscribers()
+    {
+        $idLang = (int) $this->context->language->id;
+        $hasShop = MailAlert::hasColumn('id_shop');
+
+        $sql = (new DbQuery())
+            ->select('oos.id_product')
+            ->select('NULLIF(p.reference, "") AS reference')
+            ->select('NULLIF(pl.name, "") AS product_name')
+            ->select('COUNT(DISTINCT oos.' . MailAlert::$definition['primary'] . ') AS cnt')
+            ->select('IF(oos.id_product_attribute > 0, GROUP_CONCAT(DISTINCT al.name ORDER BY agl.id_attribute_group SEPARATOR ", "), "") AS combination_name')
+            ->from(MailAlert::$definition['table'], 'oos')
+            ->leftJoin('product_lang', 'pl', 'pl.id_lang = ' . $idLang . ' AND pl.id_product = oos.id_product' . ($hasShop ? ' AND pl.id_shop = oos.id_shop' : ' AND pl.id_shop = ' . (int) $this->context->shop->id))
+            ->leftJoin('product', 'p', 'p.id_product = oos.id_product')
+            ->leftJoin('product_attribute_combination', 'pac', 'pac.id_product_attribute = oos.id_product_attribute')
+            ->leftJoin('attribute', 'a', 'a.id_attribute = pac.id_attribute')
+            ->leftJoin('attribute_lang', 'al', 'al.id_attribute = a.id_attribute AND al.id_lang = ' . $idLang)
+            ->leftJoin('attribute_group_lang', 'agl', 'agl.id_attribute_group = a.id_attribute_group AND agl.id_lang = ' . $idLang)
+            ->where($hasShop ? '1 ' . Shop::addSqlRestriction(false, 'oos') : '1')
+            ->groupBy('oos.id_product')
+            ->orderBy('COUNT(DISTINCT oos.' . MailAlert::$definition['primary'] . ') DESC');
+
+        return Db::getInstance()->executeS($sql);
+    }
+
+    /**
+     * Get list of subscribers for given product/combination
+     */
+    protected function getProductListSubscribers($idProduct)
+    {
+        $idLang = (int) $this->context->language->id;
+        $hasShop = MailAlert::hasColumn('id_shop');
+
+        $sql = (new DbQuery())
+            ->select('oos.' . MailAlert::$definition['primary'])
+            ->select('oos.id_customer')
+            ->select('IF(oos.id_product_attribute > 0, oos.id_product_attribute, NULL)')
+            ->select('oos.customer_email')
+            ->select('oos.date_add')
+            ->select('COALESCE(INET6_NTOA(oos.ip_mask), "-") AS ip_address')
+            ->select('LOWER(HEX(oos.ip_hash)) AS ip_hash')
+            ->select('oos.user_agent')
+            ->select('COALESCE((
+                            SELECT GROUP_CONCAT(al.name ORDER BY agl.id_attribute_group SEPARATOR ", ")
+                             FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
+                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.id_attribute = pac.id_attribute
+                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.id_attribute_group = a.id_attribute_group
+                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.id_attribute = al.id_attribute AND al.id_lang = ' . $idLang . ')
+                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.id_attribute_group = agl.id_attribute_group AND agl.id_lang = ' . $idLang . ')
+                             WHERE pac.id_product_attribute  = oos.id_product_attribute
+                             GROUP BY pac.id_product_attribute
+                    ), "-") AS combination_name')
+            ->select('IF(c.id_customer, CONCAT(c.firstname, " ", c.lastname), NULL) AS customer_name')
+            ->from(MailAlert::$definition['table'], 'oos')
+            ->leftJoin('product_lang', 'pl', 'pl.id_lang = ' . $idLang . ' AND pl.id_product = oos.id_product' . ($hasShop ? ' AND pl.id_shop = oos.id_shop' : ' AND pl.id_shop = ' . (int) $this->context->shop->id))
+            ->leftJoin('customer', 'c', 'oos.id_customer = c.id_customer')
+            ->where('oos.id_product = ' . (int) $idProduct . ($hasShop ? Shop::addSqlRestriction(false, 'oos') : ''))
+            ->orderBy('oos.id_product')
+            ->orderBy('oos.id_product_attribute')
+            ->orderBy('oos.date_add');
+
+        return Db::getInstance()->executeS($sql);
+    }
+
+    /**
+     * Render customer cell with link
+     */
+    public function renderCustomer($value, $row)
+    {
+        $idCustomer = (int) $row['id_customer'];
+        if (!$idCustomer) {
+            return '-';
+        }
+        $url = $this->context->link->getAdminLink('AdminCustomers', true, [
+            'id_customer' => $idCustomer,
+            'viewcustomer' => 1,
+        ]);
+        return '<a href="' . htmlspecialchars($url) . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+    /**
+     * Render product reference/name cell with link
+     */
+    public function renderProduct($value, $row)
+    {
+        $idProduct = (int) $row['id_product'];
+        $url = $this->context->link->getAdminLink('AdminProducts', true, [
+            'id_product' => $idProduct,
+            'updateproduct' => 1,
+        ]);
+        return '<a href="' . htmlspecialchars($url) . '">' . Tools::safeOutput($value) . '</a>';
+    }
+
+    /**
+     * Render number of subscriptions with link to subscriber list
+     */
+    public function renderCnt($value, $row)
+    {
+        $idProduct = (int) $row['id_product'];
+        $url = $this->context->link->getAdminLink('AdminMailalertsOos', true, [
+            'id_product' => $idProduct,
+        ]);
+        return '<a href="' . htmlspecialchars($url) . '">' . (int) $value . '</a>';
+    }
+
+    protected function renderHint()
+    {
+        return '<div class="alert alert-warning">' . $this->l('IP and user-agent information is collected for security audit purposes. The IP is saved in pseudonymised form (masked prefix + keyed hash); use the hash to detect repeat requests from the same IP without revealing the full address.') . '</div>';
+    }
+}
+

--- a/controllers/admin/index.php
+++ b/controllers/admin/index.php
@@ -18,6 +18,9 @@
  * versions in the future. If you wish to customize PrestaShop for your
  * needs please refer to https://www.prestashop.com for more information.
  *
+ * @author    PrestaShop SA <contact@prestashop.com>
+ * @copyright 2007-2016 PrestaShop SA
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
  * International Registered Trademark & Property of PrestaShop SA
  */
 

--- a/js/mailalerts.js
+++ b/js/mailalerts.js
@@ -1,24 +1,13 @@
-/**
- * 2007-2016 PrestaShop
- *
- * NOTICE OF LICENSE
- *
- * This source file is subject to the Academic Free License (AFL 3.0)
- * that is bundled with this package in the file LICENSE.txt.
- * It is also available through the world-wide-web at this URL:
- * https://opensource.org/licenses/afl-3.0.php
- * If you did not receive a copy of the license and are unable to
- * obtain it through the world-wide-web, please send an email
- * to license@prestashop.com so we can send you a copy immediately.
- *
- * DISCLAIMER
- *
- * Do not edit or add to this file if you wish to upgrade PrestaShop to newer
- * versions in the future. If you wish to customize PrestaShop for your
- * needs please refer to https://www.prestashop.com for more information.
- *
- * @author    PrestaShop SA <contact@prestashop.com>
- * @copyright 2007-2016 PrestaShop SA
- * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
- * International Registered Trademark & Property of PrestaShop SA
- */
+var oosHookJsCodeFunctions = [];
+
+function oosHookJsCode() {
+  for (var i = 0; i < oosHookJsCodeFunctions.length; i++) {
+    if (typeof oosHookJsCodeFunctions[i] === 'function') {
+      oosHookJsCodeFunctions[i]();
+    }
+  }
+}
+
+$(document).ready(function() {
+  oosHookJsCode();
+});

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -95,7 +95,7 @@ class MailAlerts extends Module
     {
         $this->name = 'mailalerts';
         $this->tab = 'administration';
-        $this->version = '4.5.0';
+        $this->version = '4.6.0';
         $this->author = 'thirty bees';
         $this->need_instance = 0;
 
@@ -167,9 +167,15 @@ class MailAlerts extends Module
             Configuration::deleteByName('MA_PRODUCT_COVERAGE');
             Configuration::deleteByName('MA_ORDER_EDIT');
             Configuration::deleteByName('MA_RETURN_SLIP');
+            Configuration::deleteByName('MAILALERTS_IP_HMAC_KEY');
+            Configuration::deleteByName('MAILALERTS_OOS_RETENTION_DAYS');
             if (! $this->uninstallDb()) {
                 return false;
             }
+        }
+
+        if (! $this->uninstallTab()) {
+            return false;
         }
 
         return parent::uninstall();
@@ -201,6 +207,10 @@ class MailAlerts extends Module
             return false;
         }
 
+        if (! $this->installTab()) {
+            return false;
+        }
+
         if ($deleteParams) {
             Configuration::updateValue('MA_MERCHANT_ORDER', 1);
             Configuration::updateValue('MA_MERCHANT_OOS', 1);
@@ -211,11 +221,14 @@ class MailAlerts extends Module
             Configuration::updateValue('MA_LAST_QTIES', (int) Configuration::get('PS_LAST_QTIES'));
             Configuration::updateGlobalValue('MA_MERCHANT_COVERAGE', 0);
             Configuration::updateGlobalValue('MA_PRODUCT_COVERAGE', 0);
+            Configuration::updateValue('MAILALERTS_OOS_RETENTION_DAYS', 365);
 
             if (! $this->installDb()) {
                 return false;
             }
         }
+
+        self::ipHmacKey();
 
         return true;
     }
@@ -230,29 +243,8 @@ class MailAlerts extends Module
      */
     public function getContent()
     {
-        if (Tools::isSubmit('delete' . $this->name)) {
-            $subscriberId = (int)Tools::getValue('id_mailalert_customer_oos');
-            $productId = (int)Tools::getValue('id_product');
-
-            if ($subscriberId) {
-                Db::getInstance()->delete('mailalert_customer_oos', 'id_mailalert_customer_oos = ' . $subscriberId);
-                $this->context->controller->confirmations[] = $this->l('The notification has been successfully deleted.');
-
-                Tools::redirectAdmin(Context::getContext()->link->getAdminLink('AdminModules', true, [
-                    'configure' => 'mailalerts',
-                    'module_name' => 'mailalerts',
-                    'id_product' => $productId,
-                ]) . '#subscribers');
-            }
-        }
-
         $html = $this->postProcess();
         $html .= $this->renderForm();
-
-        if ($this->customer_qty) {
-            $html .= "<a id='subscribers'></a>";
-            $html .= $this->renderList();
-        }
 
         return $html;
     }
@@ -273,6 +265,8 @@ class MailAlerts extends Module
                 if (!Configuration::updateValue('MA_CUSTOMER_QTY', (int)Tools::getValue('MA_CUSTOMER_QTY'))) {
                     $errors[] = $this->l('Cannot update settings');
                 } elseif (!Configuration::updateGlobalValue('MA_ORDER_EDIT', (int)Tools::getValue('MA_ORDER_EDIT'))) {
+                    $errors[] = $this->l('Cannot update settings');
+                } elseif (!Configuration::updateValue('MAILALERTS_OOS_RETENTION_DAYS', (int)Tools::getValue('MAILALERTS_OOS_RETENTION_DAYS'))) {
                     $errors[] = $this->l('Cannot update settings');
                 }
             }
@@ -390,6 +384,17 @@ class MailAlerts extends Module
                                 'label' => $this->l('Disabled'),
                             ],
                         ],
+                    ],
+                    [
+                        'type'  => 'text',
+                        'label' => $this->l('Days to keep requests'),
+                        'name'  => 'MAILALERTS_OOS_RETENTION_DAYS',
+                        'class' => 'fixed-width-sm',
+                        'suffix' => $this->l('days'),
+                        'desc'  => $this->l('Retention period (days) for out-of-stock notification requests. There’s no need to retain aged requests or those for products that are no longer stockable.')
+                            . '<br><div class="alert alert-warning">'
+                            . $this->l('IP and user-agent information is collected for security audit purposes. The IP is saved in pseudonymised form (masked prefix + keyed hash); use the hash to detect repeat requests from the same IP without revealing the full address.')
+                            . '</div>',
                     ],
                 ],
                 'submit' => [
@@ -542,182 +547,6 @@ class MailAlerts extends Module
      * @throws PrestaShopException
      * @throws SmartyException
      */
-    protected function renderList()
-    {
-        $productId = (int)Tools::getValue('id_product');
-
-        if ($productId) {
-            $product = new Product($productId, false, $this->context->language->id);
-
-            if (Validate::isLoadedObject($product)) {
-                $productName = $product->name;
-            } else {
-                $productName = $this->l('Deleted product');
-            }
-
-            $listFields = [
-                'combination_name' => [
-                    'title' => $this->l('Combination'),
-                    'type' => 'text',
-                ],
-                'customer_name' => [
-                    'title' => $this->l('Customer'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderCustomer'
-                ],
-                'customer_email' => [
-                    'title' => $this->l('Email'),
-                    'type' => 'text',
-                ],
-                'date_add' => [
-                    'title' => $this->l('Date'),
-                    'type' => 'text',
-                ],
-            ];
-
-            if (! $product->hasAttributes()) {
-                unset($listFields['combination_name']);
-            }
-
-            $helper = new HelperList();
-            $helper->shopLinkType = '';
-            $helper->simple_header = true;
-            $helper->identifier = 'id_mailalert_customer_oos';
-            $helper->actions = ['delete'];
-            $helper->no_link = true;
-            $helper->show_toolbar = false;
-            $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-                'configure' => 'mailalerts',
-                'module_name' => 'mailalerts',
-            ]);
-            $helper->title = Translate::ppTags(sprintf($this->l('Notification for "%s". [1]Show all[/1]'), $productName, $productId),  ['<a href="'.$url.'#subscribers">']);
-            $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
-            $content = $this->getProductListSubscribers($productId);
-            $helper->listTotal = count($content);
-            return $helper->generateList($content, $listFields);
-        } else {
-            $listFields = [
-                'id_product' => [
-                    'title' => $this->l('Product ID'),
-                    'type' => 'text',
-                ],
-                'reference' => [
-                    'title' => $this->l('Reference'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderProduct'
-                ],
-                'product_name' => [
-                    'title' => $this->l('Product Name'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderProduct'
-                ],
-                'combination_name' => [
-                    'title' => $this->l('Combination'),
-                    'type' => 'text',
-                ],
-                'cnt' => [
-                    'title' => $this->l('Number of subscribers'),
-                    'type' => 'text',
-                    'callback_object' => $this,
-                    'callback' => 'renderCnt'
-                ],
-            ];
-
-            $helper = new HelperList();
-            $helper->shopLinkType = '';
-            $helper->simple_header = true;
-            $helper->identifier = 'id_product';
-            $helper->actions = [];
-            $helper->no_link = true;
-            $helper->show_toolbar = false;
-            $helper->title = $this->l('Products with notifications');
-            $helper->table = $this->name;
-            $helper->token = Tools::getAdminTokenLite('AdminModules');
-            $helper->currentIndex = AdminController::$currentIndex . '&configure=' . $this->name;
-            $content = $this->getProductsSubscribers();
-            $helper->listTotal = count($content);
-            return $helper->generateList($content, $listFields);
-        }
-    }
-
-    /**
-     * Get list content
-     *
-     * @return array
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    protected function getProductsSubscribers()
-    {
-        $langId = (int)Context::getContext()->language->id;
-        $conn = Db::getInstance();
-
-        $sql = (new DbQuery())
-            ->select('oos.id_product')
-            ->select('NULLIF(p.reference, "") AS reference')
-            ->select('NULLIF(pl.name, "") AS product_name')
-            ->select('COUNT(DISTINCT oos.id_mailalert_customer_oos) as cnt')
-            ->select('IF(oos.id_product_attribute > 0, GROUP_CONCAT(DISTINCT al.name ORDER BY agl.id_attribute_group SEPARATOR ", "), "") AS combination_name')
-            ->from('mailalert_customer_oos', 'oos')
-            ->leftJoin('product_lang', 'pl', 'pl.id_lang = '.$langId.' AND pl.id_product = oos.id_product AND pl.id_shop = oos.id_shop')
-            ->leftJoin('product', 'p', 'p.id_product = oos.id_product')
-            ->leftJoin('product_attribute_combination', 'pac', 'pac.id_product_attribute = oos.id_product_attribute')
-            ->leftJoin('attribute', 'a', 'a.id_attribute = pac.id_attribute')
-            ->leftJoin('attribute_lang', 'al', 'al.id_attribute = a.id_attribute AND al.id_lang = '.$langId)
-            ->leftJoin('attribute_group_lang', 'agl', 'agl.id_attribute_group = a.id_attribute_group AND agl.id_lang = '.$langId)
-            ->where('1' . Shop::addSqlRestriction(false, 'oos'))
-            ->groupBy('oos.id_product')
-            ->orderBy('COUNT(DISTINCT oos.id_mailalert_customer_oos) DESC');
-
-        return $conn->executeS($sql);
-    }
-
-    /**
-     * Get list content
-     *
-     * @param int $productId
-     *
-     * @return array
-     *
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    protected function getProductListSubscribers($productId)
-    {
-        $langId = (int)Context::getContext()->language->id;
-        $conn = Db::getInstance();
-        $sql = (new DbQuery())
-            ->select('oos.id_mailalert_customer_oos')
-            ->select('oos.id_customer')
-            ->select('IF(oos.id_product_attribute > 0, oos.id_product_attribute, NULL)')
-            ->select('oos.customer_email')
-            ->select('oos.date_add')
-            ->select('COALESCE((
-                            SELECT GROUP_CONCAT(al.`name` ORDER BY agl.`id_attribute_group` SEPARATOR \', \')
-                             FROM `' . _DB_PREFIX_ . 'product_attribute_combination` pac
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute` a ON a.`id_attribute` = pac.`id_attribute`
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group` ag ON ag.`id_attribute_group` = a.`id_attribute_group`
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_lang` al ON (a.`id_attribute` = al.`id_attribute` AND al.`id_lang` = ' . (int)Context::getContext()->language->id . ')
-                             LEFT JOIN `' . _DB_PREFIX_ . 'attribute_group_lang` agl ON (ag.`id_attribute_group` = agl.`id_attribute_group` AND agl.`id_lang` = ' . (int)Context::getContext()->language->id . ')
-                             WHERE pac.id_product_attribute  = oos.id_product_attribute
-                             GROUP BY pac.id_product_attribute
-                    ), \'-\') AS combination_name')
-            ->select('IF(cust.id_customer, CONCAT(cust.firstname, " ", cust.lastname), NULL) AS customer_name')
-            ->from('mailalert_customer_oos', 'oos')
-            ->leftJoin('product_lang', 'pl', 'pl.id_lang = ' . $langId . ' AND pl.id_product = oos.id_product AND pl.id_shop = oos.id_shop')
-            ->leftJoin('customer', 'cust', 'oos.id_customer = cust.id_customer')
-            ->where('oos.id_product = ' . $productId . Shop::addSqlRestriction(false, 'oos'))
-            ->orderBy('oos.id_product')
-            ->orderBy('oos.id_product_attribute')
-            ->orderBy('oos.date_add');
-        return $conn->executeS($sql);
-    }
 
     /**
      * Configuration field values
@@ -737,6 +566,7 @@ class MailAlerts extends Module
             'MA_MERCHANT_MAILS'    => Tools::getValue('MA_MERCHANT_MAILS', implode(static::__MA_MAIL_DELIMITOR__, static::getMerchantEmails())),
             'MA_ORDER_EDIT'        => Tools::getValue('MA_ORDER_EDIT', Configuration::get('MA_ORDER_EDIT')),
             'MA_RETURN_SLIP'       => Tools::getValue('MA_RETURN_SLIP', Configuration::get('MA_RETURN_SLIP')),
+            'MAILALERTS_OOS_RETENTION_DAYS' => Tools::getValue('MAILALERTS_OOS_RETENTION_DAYS', Configuration::get('MAILALERTS_OOS_RETENTION_DAYS')),
         ];
     }
 
@@ -1073,7 +903,7 @@ class MailAlerts extends Module
         }
 
         if ($this->customer_qty && $quantity > 0) {
-            MailAlert::sendCustomerAlert((int) $product->id, (int) $params['id_product_attribute']);
+            MailAlert::sendCustomerAlert((int) $product->id, (int) $params['id_product_attribute'], $idShop);
         }
     }
 
@@ -1085,14 +915,15 @@ class MailAlerts extends Module
     public function hookActionProductAttributeUpdate($params)
     {
         $sql = '
-			SELECT `id_product`, `quantity`
-			FROM `'._DB_PREFIX_.'stock_available`
-			WHERE `id_product_attribute` = '.(int) $params['id_product_attribute'];
+                        SELECT `id_product`, `quantity`
+                        FROM `'._DB_PREFIX_.'stock_available`
+                        WHERE `id_product_attribute` = '.(int) $params['id_product_attribute'];
 
         $result = Db::getInstance()->getRow($sql);
+        $idShop = (int) Context::getContext()->shop->id;
 
         if ($this->customer_qty && $result['quantity'] > 0) {
-            MailAlert::sendCustomerAlert((int) $result['id_product'], (int) $params['id_product_attribute']);
+            MailAlert::sendCustomerAlert((int) $result['id_product'], (int) $params['id_product_attribute'], $idShop);
         }
     }
 
@@ -1232,8 +1063,8 @@ class MailAlerts extends Module
     {
         $controller = Dispatcher::getInstance()->getController();
         if (in_array($controller, ['product', 'account'])) {
-            $this->context->controller->addJS($this->_path.'js/mailalerts.js');
             $this->context->controller->addCSS($this->_path.'css/mailalerts.css', 'all');
+            $this->context->controller->addJS($this->_path.'js/mailalerts.js');
         }
     }
 
@@ -1450,6 +1281,48 @@ class MailAlerts extends Module
     }
 
     /**
+     * Install back office tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    private function installTab()
+    {
+        $className = 'AdminMailalertsOos';
+
+        if (Tab::getIdFromClassName($className)) {
+            return true;
+        }
+
+        $tab = new Tab();
+        $tab->class_name = $className;
+        $tab->module = $this->name;
+        $tab->id_parent = (int) Tab::getIdFromClassName('AdminCatalog');
+        $tab->active = 1;
+        foreach (Language::getLanguages(false) as $lang) {
+            $tab->name[$lang['id_lang']] = $this->l('OOS Product Notifications');
+        }
+
+        return (bool) $tab->add();
+    }
+
+    /**
+     * Remove back office tab
+     *
+     * @return bool
+     * @throws PrestaShopException
+     */
+    private function uninstallTab()
+    {
+        if ($idTab = (int) Tab::getIdFromClassName('AdminMailalertsOos')) {
+            $tab = new Tab($idTab);
+            return (bool) $tab->delete();
+        }
+
+        return true;
+    }
+
+    /**
      * Executes sql script
      * @param string $script
      * @param bool $check
@@ -1491,60 +1364,6 @@ class MailAlerts extends Module
         return true;
     }
 
-    /**
-     * @param string $value
-     * @param array $row
-     *
-     * @return string
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function renderCustomer($value, $row)
-    {
-        $customerId = (int)$row['id_customer'];
-        $url = Context::getContext()->link->getAdminLink('AdminCustomers', true, [
-            'id_customer' => $customerId,
-            'viewcustomer' => 1
-        ]);
-        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
-    }
-
-    /**
-     * @param string $value
-     * @param array $row
-     *
-     * @return string
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function renderProduct($value, $row)
-    {
-        $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminProducts', true, [
-            'id_product' => $productId,
-            'updateproduct' => 1
-        ]);
-        return '<a href="'.$url.'">'.Tools::safeOutput($value).'</a>';
-    }
-
-    /**
-     * @param string $value
-     * @param array $row
-     *
-     * @return string
-     * @throws PrestaShopDatabaseException
-     * @throws PrestaShopException
-     */
-    public function renderCnt($value, $row)
-    {
-        $productId = (int)$row['id_product'];
-        $url = Context::getContext()->link->getAdminLink('AdminModules', true, [
-            'configure' => 'mailalerts',
-            'module_name' => 'mailalerts',
-            'id_product' => $productId,
-        ]);
-        return '<a href="'.$url.'#subscribers">'.Tools::safeOutput($value).'</a>';
-    }
 
 
     /**
@@ -1610,5 +1429,50 @@ class MailAlerts extends Module
                     onclick="return confirm(\''.$this->l('Are you sure you want to delete this notification?').'\')">
                     '.$this->l('Delete').'
                 </a>';
+    }
+    // --- IP privacy helpers (HMAC + mask) ---
+    public static function ipHmacKey(): string
+    {
+        $k = Configuration::getGlobalValue('MAILALERTS_IP_HMAC_KEY');
+        if (!$k) {
+            $k = hash('sha256', _COOKIE_KEY_ . ':mailalerts:ip-hmac');
+            Configuration::updateGlobalValue('MAILALERTS_IP_HMAC_KEY', $k);
+        }
+        return $k;
+    }
+
+    /** "1.2.3.4" or "2001:db8::1" -> binary (4 or 16 bytes) or null */
+    public static function ipToBin(?string $ip): ?string
+    {
+        if (!$ip) {
+            return null;
+        }
+        $bin = @inet_pton($ip);
+        return $bin === false ? null : $bin;
+    }
+
+    /** IPv4 -> /24, IPv6 -> /64, returned as binary prefix (same 4/16-byte shape) */
+    public static function maskIpBinary(?string $bin): ?string
+    {
+        if ($bin === null) {
+            return null;
+        }
+        $len = strlen($bin);
+        if ($len === 4) {
+            return substr($bin, 0, 3) . "\x00";
+        }
+        if ($len === 16) {
+            return substr($bin, 0, 8) . str_repeat("\x00", 8);
+        }
+        return null;
+    }
+
+    /** HMAC-SHA256 over binary IP → 32-byte binary digest */
+    public static function hashIpBinary(?string $bin): ?string
+    {
+        if ($bin === null) {
+            return null;
+        }
+        return hash_hmac('sha256', $bin, self::ipHmacKey(), true);
     }
 }

--- a/mailalerts.php
+++ b/mailalerts.php
@@ -1286,7 +1286,8 @@ class MailAlerts extends Module
      * @return bool
      * @throws PrestaShopException
      */
-    private function installTab()
+
+    public function installTab()
     {
         $className = 'AdminMailalertsOos';
 

--- a/sql/install.sql
+++ b/sql/install.sql
@@ -23,7 +23,13 @@ CREATE TABLE IF NOT EXISTS `PREFIX_mailalert_customer_oos` (
   `id_product_attribute` INT(11) unsigned NOT NULL,
   `id_shop` INT(11) unsigned NOT NULL,
   `id_lang` INT(11) unsigned NOT NULL,
+  `ip_hash` VARBINARY(32) DEFAULT NULL,
+  `ip_mask` VARBINARY(16) DEFAULT NULL,
+  `user_agent` VARCHAR(255) DEFAULT NULL,
   `date_add` DATETIME NOT NULL,
+  PRIMARY KEY (`id_mailalert_customer_oos`),
   UNIQUE KEY `cust_prod` (`id_customer`,`customer_email`,`id_product`,`id_product_attribute`,`id_shop`),
-  PRIMARY KEY (`id_mailalert_customer_oos`)
+  KEY `idx_mailalert_oos_hash` (`ip_hash`),
+  KEY `idx_mailalert_oos_prod_shop` (`id_product`,`id_product_attribute`,`id_shop`),
+  KEY `idx_mailalert_oos_date` (`date_add`)
 ) ENGINE=ENGINE_TYPE DEFAULT CHARSET=CHARSET_TYPE COLLATE=COLLATE_TYPE;

--- a/sql/update_4_6_0.sql
+++ b/sql/update_4_6_0.sql
@@ -1,0 +1,25 @@
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md.
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   Academic Free License (AFL 3.0)
+ */
+ALTER TABLE `PREFIX_mailalert_customer_oos`
+  ADD COLUMN `ip_hash` VARBINARY(32) NULL AFTER `id_lang`,
+  ADD COLUMN `ip_mask` VARBINARY(16) NULL AFTER `ip_hash`,
+  ADD COLUMN `user_agent` VARCHAR(255) NULL AFTER `ip_mask`;
+
+CREATE INDEX `idx_mailalert_oos_hash` ON `PREFIX_mailalert_customer_oos` (`ip_hash`);
+CREATE INDEX `idx_mailalert_oos_prod_shop` ON `PREFIX_mailalert_customer_oos` (`id_product`,`id_product_attribute`,`id_shop`);
+CREATE INDEX `idx_mailalert_oos_date` ON `PREFIX_mailalert_customer_oos` (`date_add`);

--- a/upgrade/install-4.6.0.php
+++ b/upgrade/install-4.6.0.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Copyright (C) 2017-2024 thirty bees
+ *
+ * NOTICE OF LICENSE
+ *
+ * This source file is subject to the Academic Free License (AFL 3.0)
+ * that is bundled with this package in the file LICENSE.md
+ * It is also available through the world-wide-web at this URL:
+ * https://opensource.org/licenses/afl-3.0.php
+ * If you did not receive a copy of the license and are unable to
+ * obtain it through the world-wide-web, please send an email
+ * to license@thirtybees.com so we can send you a copy immediately.
+ *
+ * @author    thirty bees <modules@thirtybees.com>
+ * @copyright 2017-2024 thirty bees
+ * @license   https://opensource.org/licenses/afl-3.0.php  Academic Free License (AFL 3.0)
+ */
+
+if (!defined('_TB_VERSION_')) {
+    exit;
+}
+
+/**
+ * @param MailAlerts $module
+ * @return bool
+ * @throws PrestaShopException
+ */
+function upgrade_module_4_6_0($module)
+{
+    if (! $module->executeSqlScript('update_4_6_0')) {
+        return false;
+    }
+
+    $module::ipHmacKey();
+
+    return $module->installTab();
+}
+


### PR DESCRIPTION
* feat: add admin controller for OOS notifications, hooked under Catalog menu

* Align OOS controller with original product grouping

* Record subscriber IP and user agent for security audit purposes - masked and hashed IPv4 or IPv6

* feat: add retention controls and admin link

* fix: honor shop context for customer alerts